### PR TITLE
Fixed application/json response header issues

### DIFF
--- a/resources/deployment/nginx.conf.template
+++ b/resources/deployment/nginx.conf.template
@@ -41,14 +41,16 @@ http {
 
         location /api-internal {
 
+            # MIME types must be set like this
+            default_type application/json;
+
             # On success, echo back headers
             add_header "authorization" $http_authorization;
             add_header "cookie" $http_cookie;
             add_header "x-example-csrf" $http_x_example_csrf;
 
             # Return a JSON response
-            add_header "content-type" "application/json";
-            return 200 '{"message": "API was called successfully with ${http_authorization}"';
+            return 200 '{"message": "API was called successfully with ${http_authorization}"}';
         }
     }
 }

--- a/resources/localhost/nginx.conf
+++ b/resources/localhost/nginx.conf
@@ -40,14 +40,16 @@ http {
 
         location /api-internal {
 
+            # MIME types must be set like this
+            default_type application/json;
+
             # On success, echo back headers
             add_header "authorization" $http_authorization;
             add_header "cookie" $http_cookie;
             add_header "x-example-csrf" $http_x_example_csrf;
 
             # Return a JSON response
-            add_header "content-type" "application/json";
-            return 200 '{"message": "API was called successfully with ${http_authorization}"';
+            return 200 '{"message": "API was called successfully with ${http_authorization}"}';
         }
     }
 }

--- a/src/oauth_proxy_handler.c
+++ b/src/oauth_proxy_handler.c
@@ -255,6 +255,7 @@ static ngx_int_t write_options_response(ngx_http_request_t *request, oauth_proxy
 
 /*
  * Add the error response and write CORS headers so that Javascript can read it
+ * http://nginx.org/en/docs/dev/development_guide.html#http_response_body
  */
 static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t status, oauth_proxy_configuration_t *module_location_config)
 {
@@ -297,10 +298,11 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
 
             request->headers_out.status = status;
             request->headers_out.content_length_n = errorLen;
-            ngx_http_send_header(request);
 
             /* http://nginx.org/en/docs/dev/development_guide.html#http_response_body */
             ngx_str_set(&request->headers_out.content_type, "application/json");
+            ngx_http_send_header(request);
+
             body->pos = jsonErrorData;
             body->last = jsonErrorData + errorLen;
             body->memory = 1;

--- a/src/oauth_proxy_handler.c
+++ b/src/oauth_proxy_handler.c
@@ -311,7 +311,7 @@ static ngx_int_t write_error_response(ngx_http_request_t *request, ngx_int_t sta
             output.buf = body;
             output.next = NULL;
 
-            /* When setting a body ourself we must return the result of the filter, to prevent a 'header already sent' error */
+            /* When setting a body ourself we must return the result of the filter */
             return ngx_http_output_filter(request, &output);
         }
     }

--- a/t/http_get.t
+++ b/t/http_get.t
@@ -39,6 +39,9 @@ GET /t
 --- error_log
 The request did not have an origin header
 
+--- response_headers
+content-type: application/json
+
 === TEST HTTP_GET_2: GET with an untrusted origin header returns 401
 ###############################################################################################
 # Only trusted SPA clients should be able to get data from the browser due to CORS restrictions
@@ -64,6 +67,9 @@ origin: https://www.malicious-site.com
 --- error_log
 The request was from an untrusted web origin
 
+--- response_headers
+content-type: application/json
+
 === TEST HTTP_GET_3: GET without a cookie or token credential returns 401
 ##########################################################################################
 # Verify that a 401 is received when there is no message credential at all sent to the API
@@ -88,6 +94,9 @@ origin: https://www.example.com
 
 --- error_log
 No AT cookie was found in the incoming request
+
+--- response_headers
+content-type: application/json
 
 === TEST HTTP_GET_4: GET with an invalid cookie returns 401
 #####################################################################################
@@ -117,6 +126,9 @@ $data;
 --- error_log
 Invalid data length after decoding from base64
 
+--- response_headers
+content-type: application/json
+
 === TEST HTTP_GET_5: GET returns correct CORS response headers with module errors
 #################################################################################
 # Verify that when a 401 is received the SPA can read details due to CORS headers
@@ -143,6 +155,7 @@ $data;
 --- error_code: 401
 
 --- response_headers
+content-type: application/json
 access-control-allow-origin: https://www.example.com
 access-control-allow-credentials: true
 
@@ -178,7 +191,7 @@ $data;
 --- error_code: 200
 
 --- response_headers eval
-"authorization: Bearer " . $main::at_opaque
+"authorization: Bearer " . $main::at_opaque;
 
 === TEST HTTP_GET_7: GET with a valid request and CORS enabled returns the correct CORS response headers
 #######################################################################

--- a/t/http_post.t
+++ b/t/http_post.t
@@ -48,6 +48,9 @@ $data;
 --- error_log
 No CSRF cookie was found in the incoming request
 
+--- response_headers
+content-type: application/json
+
 === TEST HTTP_POST_2: POST with no CSRF request header returns 401
 ############################################################
 # A request header should be sent along with the CSRF cookie
@@ -75,6 +78,9 @@ $data;
 
 --- error_log
 A data changing request did not have a CSRF header
+
+--- response_headers
+content-type: application/json
 
 === TEST HTTP_POST_3: POST with mismatched CSRF request header and cookie returns 401
 ##################################################################
@@ -104,6 +110,9 @@ $data;
 
 --- error_log
 The CSRF request header did not match the value in the encrypted CSRF cookie
+
+--- response_headers
+content-type: application/json
 
 === TEST HTTP_POST_4: POST with 2 valid cookies and a CSRF token returns 200
 #############################################################


### PR DESCRIPTION
For error responses, the `application/json` response header was written incorrectly.\
Fix this by moving the setting of the header before the `ngx_http_send_header()` call.

Also, for local macOS and local Docker testing, JSON responses were incorrect:

- There was a missing `}` in the test JSON response body.
- The content-type directive in the location block should be set according to [this answer](https://serverfault.com/questions/611256/nginx-add-header-is-not-working).