### PR TITLE
Same domain CORS fix

### DIFF
--- a/t/http_get.t
+++ b/t/http_get.t
@@ -319,3 +319,36 @@ No AT cookie was found in the incoming request
 
 --- response_body_like chomp
 {"code":"unauthorized","message":"Access denied due to missing or invalid credentials"}
+
+=== TEST HTTP_GET_11: Same origin GET with a valid cookie returns 200 and an Authorization header
+#########################################################################################################
+# Ensure that GET requests work as expected when same domain hosting is used and no origin header is sent
+#########################################################################################################
+
+--- config
+location /t {
+    oauth_proxy on;
+    oauth_proxy_cookie_name_prefix "example";
+    oauth_proxy_encryption_key "4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50";
+    oauth_proxy_trusted_web_origin "https://www.example.com";
+    oauth_proxy_cors_enabled off;
+
+    proxy_pass http://localhost:1984/target;
+}
+location /target {
+    add_header 'authorization' $http_authorization;
+    return 200;
+}
+
+--- request
+GET /t
+
+--- more_headers eval
+my $data;
+$data .= "cookie: example-at=" . $main::at_opaque_cookie . "\n";
+$data;
+
+--- error_code: 200
+
+--- response_headers eval
+"authorization: Bearer " . $main::at_opaque;


### PR DESCRIPTION
Avoid checking for the origin header on GET or HEAD requests when CORS is disabled. This prevents problems in setups where the web content and token handler are hosted on the same domain, eg:

https://www.example.com
https://www.example.com/api

For data changing requests it is still a CSRF best practice to check the origin header, even in same site setups.