### PR TITLE
Updated to latest openssl for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ADD nginx-$NGINX_VERSION.tar.gz /tmp/
 
 WORKDIR /tmp
 RUN wget https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.gz && mkdir -p pcre && tar -xz -C pcre -f pcre-8.44.tar.gz --strip-components=1
-RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.12.tar.gz --strip-components=1
+RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.13.tar.gz --strip-components=1
 RUN CONFIG_OPTS="--with-pcre=../pcre --with-zlib=../zlib" ./configure && make
 
 ######
@@ -50,7 +50,7 @@ ADD nginx-$NGINX_VERSION.tar.gz /tmp/
 
 WORKDIR /tmp
 RUN wget https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.gz && mkdir -p pcre && tar -xz -C pcre -f pcre-8.44.tar.gz --strip-components=1
-RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.12.tar.gz --strip-components=1
+RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.13.tar.gz --strip-components=1
 RUN CONFIG_OPTS="--with-pcre=../pcre --with-zlib=../zlib" ./configure && make
 
 ######
@@ -103,7 +103,7 @@ ADD nginx-$NGINX_VERSION.tar.gz /tmp/
 
 WORKDIR /tmp
 RUN wget https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.gz && mkdir -p pcre && tar -xz -C pcre -f pcre-8.44.tar.gz --strip-components=1
-RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.12.tar.gz --strip-components=1
+RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.13.tar.gz --strip-components=1
 RUN CONFIG_OPTS="--with-pcre=../pcre --with-zlib=../zlib" ./configure && make
 
 ######
@@ -122,7 +122,7 @@ ADD nginx-$NGINX_VERSION.tar.gz /tmp/
 
 WORKDIR /tmp
 RUN wget https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.gz && mkdir -p pcre && tar -xz -C pcre -f pcre-8.44.tar.gz --strip-components=1
-RUN wget https://www.zlib.net/zlib-1.2.12.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.12.tar.gz --strip-components=1
+RUN wget https://www.zlib.net/zlib-1.2.13.tar.gz && mkdir -p zlib && tar -xz -C zlib -f zlib-1.2.13.tar.gz --strip-components=1
 RUN CONFIG_OPTS="--with-pcre=../pcre --with-zlib=../zlib" ./configure && make
 
 ######

--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@ set -e
 SRC_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 NGINX_VERSION=${NGINX_VERSION:-1.21.6}
-OPENSSL_VERSION_TAG='OpenSSL_1_1_1p'
+OPENSSL_VERSION_TAG='OpenSSL_1_1_1s'
 BUILD_INFO_FILE="$SRC_DIR/.build.info"
 test -f "$BUILD_INFO_FILE" && . "$BUILD_INFO_FILE"
 

--- a/resources/localhost/openssl_install.sh
+++ b/resources/localhost/openssl_install.sh
@@ -10,7 +10,7 @@ cd ../..
 #
 # Get the code
 #
-curl -O -L https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1p.tar.gz
+curl -O -L https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1s.tar.gz
 if [ $? -ne 0 ]; then
   >&2 echo 'Problem encountered downloading OpenSSL source code'
   exit 1
@@ -19,8 +19,8 @@ fi
 #
 # Unzip it
 #
-rm -rf openssl-OpenSSL_1_1_1p
-tar xzvf OpenSSL_1_1_1p.tar.gz
+rm -rf openssl-OpenSSL_1_1_1s
+tar xzvf OpenSSL_1_1_1s.tar.gz
 if [ $? -ne 0 ]; then
   >&2 echo 'Problem encountered unzipping OpenSSL archive'
   exit 1
@@ -29,7 +29,7 @@ fi
 #
 # Configure it
 #
-cd openssl-OpenSSL_1_1_1p
+cd openssl-OpenSSL_1_1_1s
 ./config
 if [ $? -ne 0 ]; then
   >&2 echo 'Problem encountered configuring OpenSSL'


### PR DESCRIPTION
Note that the openssl that actually runs on a deployed nginx system is not determined by the plugin.
Also updated to the latest zlib version, since the old link used by the build system was broken.